### PR TITLE
alpineベースにする

### DIFF
--- a/docker/app/Dockerfile.alpine
+++ b/docker/app/Dockerfile.alpine
@@ -17,17 +17,17 @@ RUN apk update && \
 
 FROM ruby:3.0.2-alpine
 
+WORKDIR /sandbox-rails
+
 RUN apk update && \
     apk add --no-cache \
         postgresql-dev \
-        tzdata 
-
-WORKDIR /sandbox-rails
+        tzdata && \
+    adduser -D app && chown -R app /sandbox-rails
 
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY . /sandbox-rails
 
-RUN adduser -D app && chown -R app /sandbox-rails
 USER app
 
 EXPOSE 3000


### PR DESCRIPTION
resolve #6 

- alpine & マルチステージビルド

### BEFORE
- TOTAL 1.06GB
```shell
$ d history 1918c51f0cf8
IMAGE          CREATED          CREATED BY                                      SIZE      COMMENT
1918c51f0cf8   42 seconds ago   CMD ["bundle" "exec" "rails" "server" "-b" "…   0B        buildkit.dockerfile.v0
<missing>      42 seconds ago   EXPOSE map[3000/tcp:{}]                         0B        buildkit.dockerfile.v0
<missing>      42 seconds ago   COPY . /sandbox-rails # buildkit                32MB      buildkit.dockerfile.v0
<missing>      46 hours ago     COPY /usr/local/bundle/ /usr/local/bundle/ #…   144MB     buildkit.dockerfile.v0
<missing>      46 hours ago     WORKDIR /sandbox-rails                          0B        buildkit.dockerfile.v0
<missing>      10 days ago      /bin/sh -c #(nop)  CMD ["irb"]                  0B        
<missing>      10 days ago      /bin/sh -c mkdir -p "$GEM_HOME" && chmod 777…   0B        
<missing>      10 days ago      /bin/sh -c #(nop)  ENV PATH=/usr/local/bundl…   0B        
<missing>      10 days ago      /bin/sh -c #(nop)  ENV BUNDLE_SILENCE_ROOT_W…   0B        
<missing>      10 days ago      /bin/sh -c #(nop)  ENV GEM_HOME=/usr/local/b…   0B        
<missing>      10 days ago      /bin/sh -c set -eux;   savedAptMark="$(apt-m…   47.3MB    
<missing>      10 days ago      /bin/sh -c #(nop)  ENV RUBY_DOWNLOAD_SHA256=…   0B        
<missing>      10 days ago      /bin/sh -c #(nop)  ENV RUBY_VERSION=3.0.2       0B        
<missing>      10 days ago      /bin/sh -c #(nop)  ENV RUBY_MAJOR=3.0           0B        
<missing>      10 days ago      /bin/sh -c #(nop)  ENV LANG=C.UTF-8             0B        
<missing>      10 days ago      /bin/sh -c set -eux;  mkdir -p /usr/local/et…   45B       
<missing>      10 days ago      /bin/sh -c set -ex;  apt-get update;  apt-ge…   528MB     
<missing>      10 days ago      /bin/sh -c apt-get update && apt-get install…   152MB     
<missing>      10 days ago      /bin/sh -c set -ex;  if ! command -v gpg > /…   18.9MB    
<missing>      10 days ago      /bin/sh -c set -eux;  apt-get update;  apt-g…   10.7MB    
<missing>      11 days ago      /bin/sh -c #(nop)  CMD ["bash"]                 0B        
<missing>      11 days ago      /bin/sh -c #(nop) ADD file:aea313ae50ce6474a…   124MB
```

## AFTER
- TOTAL 538MB
```shell
$ d history 4aa8ad1862f2
IMAGE          CREATED              CREATED BY                                      SIZE      COMMENT
4aa8ad1862f2   About a minute ago   CMD ["bundle" "exec" "rails" "server" "-b" "…   0B        buildkit.dockerfile.v0
<missing>      About a minute ago   EXPOSE map[3000/tcp:{}]                         0B        buildkit.dockerfile.v0
<missing>      About a minute ago   USER app                                        0B        buildkit.dockerfile.v0
<missing>      About a minute ago   COPY . /sandbox-rails # buildkit                32MB      buildkit.dockerfile.v0
<missing>      6 minutes ago        COPY /usr/local/bundle/ /usr/local/bundle/ #…   128MB     buildkit.dockerfile.v0
<missing>      6 minutes ago        RUN /bin/sh -c apk update &&     apk add --n…   318MB     buildkit.dockerfile.v0
<missing>      20 hours ago         WORKDIR /sandbox-rails                          0B        buildkit.dockerfile.v0
<missing>      8 weeks ago          /bin/sh -c #(nop)  CMD ["irb"]                  0B        
<missing>      8 weeks ago          /bin/sh -c mkdir -p "$GEM_HOME" && chmod 777…   0B        
<missing>      8 weeks ago          /bin/sh -c #(nop)  ENV PATH=/usr/local/bundl…   0B        
<missing>      8 weeks ago          /bin/sh -c #(nop)  ENV BUNDLE_SILENCE_ROOT_W…   0B        
<missing>      8 weeks ago          /bin/sh -c #(nop)  ENV GEM_HOME=/usr/local/b…   0B        
<missing>      8 weeks ago          /bin/sh -c set -eux;   apk add --no-cache --…   43.4MB    
<missing>      8 weeks ago          /bin/sh -c #(nop)  ENV RUBY_DOWNLOAD_SHA256=…   0B        
<missing>      8 weeks ago          /bin/sh -c #(nop)  ENV RUBY_VERSION=3.0.2       0B        
<missing>      8 weeks ago          /bin/sh -c #(nop)  ENV RUBY_MAJOR=3.0           0B        
<missing>      8 weeks ago          /bin/sh -c #(nop)  ENV LANG=C.UTF-8             0B        
<missing>      8 weeks ago          /bin/sh -c set -eux;  mkdir -p /usr/local/et…   45B       
<missing>      8 weeks ago          /bin/sh -c set -eux;  apk add --no-cache   b…   11.4MB    
<missing>      8 weeks ago          /bin/sh -c #(nop)  CMD ["/bin/sh"]              0B        
<missing>      8 weeks ago          /bin/sh -c #(nop) ADD file:aad4290d27580cc1a…   5.6MB
```